### PR TITLE
Add assumeRole before doing servicequotas.

### DIFF
--- a/controllers/account/ec2.go
+++ b/controllers/account/ec2.go
@@ -164,7 +164,7 @@ func (r *AccountReconciler) InitializeRegion(
 		// Check if a request is necessary
 		// If there are errors, this will return false, and will not continue to try
 		// to set the quota
-		quotaIncreaseRequired, err = serviceQuotaNeedsIncrease(awsClient, string(awsv1alpha1.VCPUQuotaCode), string(awsv1alpha1.VCPUServiceCode), vCPUQuota)
+		quotaIncreaseRequired, err = serviceQuotaNeedsIncrease(reqLogger, awsClient, string(awsv1alpha1.VCPUQuotaCode), string(awsv1alpha1.VCPUServiceCode), vCPUQuota)
 		if err != nil {
 			reqLogger.Error(err, "failed retrieving current vCPU quota from AWS")
 		}
@@ -172,7 +172,7 @@ func (r *AccountReconciler) InitializeRegion(
 
 	if quotaIncreaseRequired {
 		reqLogger.Info("vCPU quota increase required", "region", region)
-		caseID, err = checkQuotaRequestHistory(awsClient, string(awsv1alpha1.VCPUQuotaCode), string(awsv1alpha1.VCPUServiceCode), vCPUQuota)
+		caseID, err = checkQuotaRequestHistory(reqLogger, awsClient, string(awsv1alpha1.VCPUQuotaCode), string(awsv1alpha1.VCPUServiceCode), vCPUQuota)
 		if err != nil {
 			reqLogger.Error(err, "failed retrieving quota change history")
 		}

--- a/hack/scripts/set_operator_configmap.sh
+++ b/hack/scripts/set_operator_configmap.sh
@@ -90,4 +90,4 @@ if [ -z "${SUPPORT_JUMP_ROLE+x}" ]; then
 fi
 
 echo "Deploying AWS Account Operator Configmap"
-oc process -p ROOT="${AWS_ROOT_OU}" -p BASE="${AWS_BASE_OU}" -p ACCOUNTLIMIT="${AWS_ACCOUNT_LIMIT}" -p VCPU_QUOTA="${AWS_VCPU_QUOTA}" -p OPERATOR_NAMESPACE=aws-account-operator -p STS_JUMP_ARN="${STS_JUMP_ARN}" -p SUPPORT_JUMP_ROLE="${SUPPORT_JUMP_ROLE}" -f hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl | oc apply -f -
+oc process -p ROOT="${AWS_ROOT_OU}" -p BASE="${AWS_BASE_OU}" -p ACCOUNT_LIMIT="${AWS_ACCOUNT_LIMIT}" -p VCPU_QUOTA="${AWS_VCPU_QUOTA}" -p OPERATOR_NAMESPACE=aws-account-operator -p STS_JUMP_ARN="${STS_JUMP_ARN}" -p SUPPORT_JUMP_ROLE="${SUPPORT_JUMP_ROLE}" -f hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl | oc apply -f -

--- a/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
+++ b/hack/templates/aws.managed.openshift.io_v1alpha1_configmap.tmpl
@@ -3,7 +3,7 @@ kind: Template
 parameters:
 - name: ROOT
 - name: BASE
-- name: ACCOUNTLIMIT
+- name: ACCOUNT_LIMIT
 - name: VCPU_QUOTA
 - name: OPERATOR_NAMESPACE
 - name: STS_JUMP_ARN
@@ -20,7 +20,7 @@ objects:
     root: ${ROOT}
     base: ${BASE}
     quota.vcpu: ${VCPU_QUOTA}
-    account-limit: ${ACCOUNTLIMIT}
+    account-limit: ${ACCOUNT_LIMIT}
     MaxConcurrentReconciles.account: "2"
     MaxConcurrentReconciles.accountvalidation: "2"
     MaxConcurrentReconciles.accountclaim: "1"


### PR DESCRIPTION
The requests must be opened inside the account that is being setup, not the general AWS account.

Move the assumeRole call into a global variable so it can be mocked in the tests.

# What is being added?
_Is this a fix for a bug?  What's the bug?  Is this a new feature? Please describe it. Is this just a small typo fix?  That's fine too!_

## Checklist before requesting review

- [ ] I have tested this locally
- [ ] I have included unit tests
- [ ] I have updated any corresponding documentation

## Steps To Manually Test
_Please provide us steps to reproduce the scenarios needed to test this.  If an integration test is provided, let us know how to run it. If not, enumerate the steps to validate this does what it's supposed to._
1. Start the operator
1. Run the thing
1. Observe X in the spec for the thing
1. Clean up the thing

Ref OSD-0000
